### PR TITLE
Fix .SG-header background position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 docs/build
 styleguide
+npm-debug.log

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,8 +1,9 @@
-# Contributers
+# Contributors
 
 Sorted alphabeticaly by first name. [Full list of contributers](https://github.com/holidaypirates/nucleus/graphs/contributors)
 
 Michael Seibt ([GitHub](https://github.com/michaelseibt) &bull; [Twitter](https://twitter.com/divis0r))
+Thomas Carlson ([Github](https://github.com/thomas0c) &bull; [Twitter](https://twitter.com/thomasoc))
 
 # Special thanks to
 

--- a/assets/styles/structures/header.scss
+++ b/assets/styles/structures/header.scss
@@ -7,6 +7,14 @@
 // This software may be modified and distributed under the terms
 // of the MIT license. See the LICENSE file for details.
 
+/* ...
+ *
+ * With contributions from:
+ *  - Thomas Carlson (@thomasoc)
+ *
+ * ...
+ */
+
 /**
  * Header bar with logo, navigation, and tool icons at the top of the page.
  *
@@ -26,6 +34,7 @@
   border-bottom: 1px solid $color--whitesmoke;
   padding: 0 40px;
   margin-bottom: 100px;
+  position: relative;
 
   &::before {
     content: '';

--- a/build/styles/app.css
+++ b/build/styles/app.css
@@ -2716,6 +2716,7 @@ body {
   font-family: Lato, sans-serif;
   font-size: 14px;
   margin: 0;
+  position: relative;
   padding: 0;
   border-bottom: 1px solid #efefef;
   padding: 0 40px;


### PR DESCRIPTION
Experienced and tested in Chrome 53 on Mac OS X El Capitan.

Due to a missing `position:relative` in for `.SG-header` the `::before` content was floating below the view height. By adding `position:relative` to `.SG-header` the `::before` content correctly positions itself relative to the header class.

This PR solves that by adding `position:relative` to `.SG-header`.

See image below for bug.
![screen shot 2016-08-16 at 2 22 18 pm](https://cloud.githubusercontent.com/assets/8699937/17711258/ba514806-63be-11e6-87b6-843c34ff2613.png)
