### PR TITLE
Allow user to customize styleguide theme

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@
 
 Sorted alphabeticaly by first name. [Full list of contributers](https://github.com/holidaypirates/nucleus/graphs/contributors)
 
+Marco Vito Moscaritolo ([GitHub](https://github.com/mavimo) &bull; [Twitter](https://twitter.com/mavimo))
 Michael Seibt ([GitHub](https://github.com/michaelseibt) &bull; [Twitter](https://twitter.com/divis0r))
 Thomas Carlson ([Github](https://github.com/thomas0c) &bull; [Twitter](https://twitter.com/thomasoc))
 

--- a/docs/src/views/configuration.pug
+++ b/docs/src/views/configuration.pug
@@ -77,6 +77,22 @@ block content
       div.SG-config__label Example
       div.SG-config__value nucleus --css /assets/app.css
 
+  h3.SG-h3 Template
+  p.SG-p If you want customize the generated layout you can copy the [default theme](https://github.com/holidaypirates/nucleus/tree/master/assets/views) and customize it.
+  div.SG-config
+    div.SG-config__row
+      div.SG-config__label CLI flag
+      div.SG-config__value --template
+    div.SG-config__row
+      div.SG-config__label Config key
+      div.SG-config__value template
+    div.SG-config__row
+      div.SG-config__label Default value
+      div.SG-config__value undefined
+    div.SG-config__row
+      div.SG-config__label Example
+      div.SG-config__value nucleus --template=./styleguide/my-theme
+
   h3.SG-h3 Static dummy texts and images
   p.SG-p For easier visual regression testing, you may disable the generation of randomized lipsum texts and image placeholders. With this option enabled, you will always get the same (boring) placeholders.
   div.SG-config

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@
  *
  * Copyright (C) 2016 Michael Seibt
  *
- * With contributions from: -
+ * With contributions from:
+ *  - Marco Vito Moscaritolo (@mavimo)
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ require('mkdirp').sync(config.target);
 var templateFiles = ['atoms', 'molecules', 'index', 'nuclides', 'structures'];
 for(var t in templateFiles) {
   Verbose.spin('Generating files');
-  var html = jade.renderFile(__dirname + '/assets/views/'+templateFiles[t]+'.pug', {
+  var html = jade.renderFile(config.template.replace(/\/$/, '')+'/'+templateFiles[t]+'.pug', {
     styles : styleguides,
     index: searchIndex,
     meta: {

--- a/src/Config.js
+++ b/src/Config.js
@@ -12,6 +12,7 @@
 
 'use strict';
 
+var fs = require('fs');
 var merge = require('merge');
 var argv = require('yargs')
             .alias('c', 'config')
@@ -34,6 +35,8 @@ var Config = {};
  */
 Config.parse = function () {
   var defaultConfig = require('../default.nucleus.json');
+  defaultConfig.template = __dirname + '/../assets/views';
+
   var config = defaultConfig;
 
   // Are we allowed to talk at all?
@@ -85,6 +88,14 @@ Config.parse = function () {
     Verbose.error('no_target');
   }
 
+  // No valid template folder, no styleguide !
+  try {
+    fs.accessSync(config.template, fs.F_OK);
+  } catch (e) {
+    config.template = __dirname + '/../assets/views';
+    Verbose.error('no_valid_template');
+  }
+
   config.files = files;
   return config;
 };
@@ -110,6 +121,7 @@ Config.getFromArguments = function () {
   if(argv.verbose) cliConfig.verbose = argv.verbose;
   if(argv.target)  cliConfig.target = argv.target;
   if(argv.title)   cliConfig.title = argv.title;
+  if(argv.template)  cliConfig.template = argv.template;
   if(argv.norandom)  cliConfig.staticLipsum = !!argv.norandom;
   return cliConfig;
 };

--- a/src/Config.js
+++ b/src/Config.js
@@ -2,7 +2,8 @@
  *
  * Copyright (C) 2016 Michael Seibt
  *
- * With contributions from: -
+ * With contributions from:
+ *  - Marco Vito Moscaritolo (@mavimo)
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/src/messages/errors.js
+++ b/src/messages/errors.js
@@ -72,5 +72,14 @@ module.exports = {
         'At least, you could add an empty rule.'
     };
   },
+  'no_valid_template': function() {
+    return {
+      'title': 'Template folder is not valid.',
+      'text': 'Double-check the ' + chalk.underline('template') + ' property in the configuration. ' +
+        'This should be a valid folder with template files to generate a valid styleguide.' +
+        'Default template is used. ' +
+        'Btw, the current working dir is ' + process.cwd()
+    };
+  },
 
 };

--- a/src/messages/errors.js
+++ b/src/messages/errors.js
@@ -2,7 +2,8 @@
  *
  * Copyright (C) 2016 Michael Seibt
  *
- * With contributions from: -
+ * With contributions from:
+ *  - Marco Vito Moscaritolo (@mavimo)
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.


### PR DESCRIPTION
Allow user to customize styleguide theme by copy and modify the `assets/views` folder.
Theme path should be specified by config file or by flag as reported in the doc.

Eg:

```
{
    "title":"Nucleus",
    "files":[
        "src/**/*.scss"
    ],
    "target":"web/styleguide",
    "css":"",
    "namespace":"",
    "verbose":3,
    "counterCSS":null,
    "template": "./my-theme",
    "staticLipsum":false
}
```
