### PR TITLE
Fix typo on local execution command of nucleus

### DIFF
--- a/docs/src/views/installation.pug
+++ b/docs/src/views/installation.pug
@@ -29,7 +29,7 @@ block content
     This documentation is assuming you've installed Nucleus globally. If you've decided for
     the local setup, you've got to run it like
   code.
-    node ./node_modules/bin/nucleus
+    node ./node_modules/.bin/nucleus
 
   h2.SG-h2 A handy shortcut
   p.SG-p.


### PR DESCRIPTION
* Replace `./node_modules/bin/nucleus` by `./node_modules/.bin/nucleus` (missed `.` before `bin`)