### PR TITLE
doc(getting started): fix example spacing error

### DIFF
--- a/docs/src/views/getting-started.pug
+++ b/docs/src/views/getting-started.pug
@@ -34,10 +34,10 @@ block content
      * @modifiers
      *  .button--alert an alert button
      * @markup
-     *   &lt;button class="button"&gt;A button&lt;/button&gt;
-     *   &lt;button class="button button--alert"&gt;
-     *     An alert button
-     *   &lt;/button&gt;
+     *  &lt;button class="button"&gt;A button&lt;/button&gt;
+     *  &lt;button class="button button--alert"&gt;
+     *    An alert button
+     *  &lt;/button&gt;
      */
     .button {
      /* ... */


### PR DESCRIPTION
Fixes a spacing error which causes the generated markup to be wrongly indented due to three spaces instead of 2.