### PR TITLE
(gh-pags): fix Annotation Reference mixin example

### DIFF
--- a/annotation-reference.html
+++ b/annotation-reference.html
@@ -19,6 +19,7 @@ $color: #000;
  * Put rounded borders around the element
  * and a border color.
  *
+ * @mixin
  * @section Style Mixins
  * @param $radius This could be single line ...
  * @param $color


### PR DESCRIPTION
why?
missing mixin type for DocBlock

how?
i add mixin type for DocBlock's example !

i ♥ nucleus
thx : )